### PR TITLE
fix rust repo url

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,4 +22,4 @@ the consumer.
 
 - [Python](https://github.com/cloudchacho/hedwig-python)
 - [Golang](https://github.com/cloudchacho/hedwig-go)
-- [Rust](https://github.com/cloudchacho/hedwig-rust)
+- [Rust](https://github.com/standard-ai/hedwig-rust)


### PR DESCRIPTION
This fixes the URL in the documentation for the `hedwig-rust` repository. The only other reference in `Library Spec.md` is currently correct.